### PR TITLE
Making floating point comparison easier

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -68,6 +68,7 @@ go_test(
         "//utils",
         "@com_github_alpacahq_alpaca_trade_api_go_v3//marketdata",
         "@com_github_google_go_cmp//cmp",
+        "@com_github_google_go_cmp//cmp/cmpopts",
         "@org_golang_google_protobuf//proto",
     ],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,8 +9,6 @@ module(
     version = "1.0",
 )
 
-
-
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
 
 # If the Gazelle plugin is needed:

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 3,
-  "moduleFileHash": "19a29395570bc381a39cda91050c6e1374844201dcd54f9939b89375539816d9",
+  "moduleFileHash": "354648757067b0ef71b30a794d3367e9b4cd5e5ddfaad7caf233aafe7e45f548",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"
@@ -30,7 +30,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 21,
+            "line": 19,
             "column": 23
           },
           "imports": {},
@@ -45,7 +45,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 25,
+            "line": 23,
             "column": 24
           },
           "imports": {
@@ -67,7 +67,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 26,
+                "line": 24,
                 "column": 18
               }
             }
@@ -1157,8 +1157,8 @@
         "accumulatedFileDigests": {
           "@@rules_go~0.43.0//:go.mod": "58f9901703af412a1a8771d283721ef391c0ca1cc6ef3c141334311965535676",
           "@@gazelle~0.34.0//:go.mod": "9ae159a385b2f244bbe964b9f91dbea6e7bd534e0b22e846655f241c65de2c49",
-          "@@//:go.mod": "714e4c15b6282a48060c0619bdc4668d75d5be437e4e0b890e55533b5e632d1b",
-          "@@//:go.sum": "d3f8ac2a69169bccbd41a3f0a2c9264ca02973b22fa857433b9b7a635c715b0c",
+          "@@//:go.mod": "66122c0c1f688649f9eb5b5e4e294a8bf4db8d59a30726bc98dc58cd2919c83b",
+          "@@//:go.sum": "bded80bc0801464ecbc6cccc6c2af0378ca030f6553642638f6d3728f1fdcd0c",
           "@@rules_go~0.43.0//:go.sum": "c6368ec1da45691f9148115d7317e740c3b32313b624b8f6545ef36b2ab4d781",
           "@@gazelle~0.34.0//:go.sum": "7469786f3930030c430969cedae951e6947cb40f4a563dac94a350659c0fedc4"
         },

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/alpacahq/alpaca-trade-api-go/v3 v3.0.1
-	github.com/google/go-cmp v0.5.9
+	github.com/google/go-cmp v0.6.0
 	github.com/polygon-io/client-go v1.13.1
 	github.com/rs/zerolog v1.29.1
 	goa.design/goa/v3 v3.11.3

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/go-resty/resty/v2 v2.7.0/go.mod h1:9PWDzw47qPphMRFfhsyk0NnSgvluHcljSM
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
-github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gxui v0.0.0-20151028112939-f85e0a97b3a4 h1:OL2d27ueTKnlQJoqLW2fc9pWYulFnJYLWzomGV7HqZo=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/stox_test.go
+++ b/stox_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/alpacahq/alpaca-trade-api-go/v3/marketdata"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/t-hale/stox/gen/stox"
 	"github.com/t-hale/stox/utils"
 	"google.golang.org/protobuf/proto"
@@ -84,7 +85,7 @@ func TestCalculateVestDates(t *testing.T) {
 						TotalUnitsGranted:  proto.Int64(30),
 						UnitsRemaining:     proto.Int64(90),
 						AmountGranted:      proto.Float64(1001.3),
-						TotalAmountGranted: proto.Float64(3003.8999999999996),
+						TotalAmountGranted: proto.Float64(3003.8999),
 					},
 					{
 						Date:               utils.PtrTo(stox.Date("2024-01-13")),
@@ -108,7 +109,7 @@ func TestCalculateVestDates(t *testing.T) {
 						TotalUnitsGranted:  proto.Int64(60),
 						UnitsRemaining:     proto.Int64(60),
 						AmountGranted:      proto.Float64(1001.3),
-						TotalAmountGranted: proto.Float64(6007.799999999999),
+						TotalAmountGranted: proto.Float64(6007.7999),
 					},
 					{
 						Date:               utils.PtrTo(stox.Date("2024-04-13")),
@@ -116,7 +117,7 @@ func TestCalculateVestDates(t *testing.T) {
 						TotalUnitsGranted:  proto.Int64(70),
 						UnitsRemaining:     proto.Int64(50),
 						AmountGranted:      proto.Float64(1001.3),
-						TotalAmountGranted: proto.Float64(7009.099999999999),
+						TotalAmountGranted: proto.Float64(7009.0999),
 					},
 					{
 						Date:               utils.PtrTo(stox.Date("2024-05-13")),
@@ -132,7 +133,7 @@ func TestCalculateVestDates(t *testing.T) {
 						TotalUnitsGranted:  proto.Int64(90),
 						UnitsRemaining:     proto.Int64(30),
 						AmountGranted:      proto.Float64(1001.3),
-						TotalAmountGranted: proto.Float64(9011.699999999999),
+						TotalAmountGranted: proto.Float64(9011.6999),
 					},
 					{
 						Date:               utils.PtrTo(stox.Date("2024-07-13")),
@@ -156,7 +157,7 @@ func TestCalculateVestDates(t *testing.T) {
 						TotalUnitsGranted:  proto.Int64(120),
 						UnitsRemaining:     proto.Int64(0),
 						AmountGranted:      proto.Float64(1001.3),
-						TotalAmountGranted: proto.Float64(12015.599999999999),
+						TotalAmountGranted: proto.Float64(12015.5999),
 					},
 				},
 			},
@@ -304,7 +305,7 @@ func TestCalculateVestDates(t *testing.T) {
 
 		}
 
-		if diff := cmp.Diff(tc.want, got); diff != "" {
+		if diff := cmp.Diff(tc.want, got, cmpopts.EquateApprox(0, 0.0001)); diff != "" {
 			t.Errorf("TestCalculateVestDates() mismatch (-want +got):\n%s", diff)
 		}
 


### PR DESCRIPTION
Use the [github.com/google/go-cmp/cmp/cmpopts](https://pkg.go.dev/github.com/google/go-cmp/cmp/cmpopts) package to compare floats in unit tests